### PR TITLE
Illustrate growing Gemfile practice for gems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ bin/*
 
 # RSpec
 /spec/examples.txt
+
+# don't include lockfile in a gem
+/Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gemspec
+
+group :test, :development do
+  gem 'chef-dk', '= 0.10.0'
+end


### PR DESCRIPTION
This way folks installing your gem do not have to install your test and development dependencies by default.