### PR TITLE
Correct require stmt in README and post-install msg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for chefdk-julia
 
+## 0.4.3
+* Update README and gem post-install message with correct require statement
+
 ## 0.4.2
 * Fix ERROR: Could not find cookbook(s) to satisfy run list ["recipe[chefdk-julia-0.4.1::cookbook]"]
   See https://github.com/chef/chef-dk/issues/633

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ Add these lines to your `~/.chef/config.rb` or `~/.chef/knife.rb` configuration 
 
 ```ruby
 # Paste lines below into ~/.chef/config.rb or knife.rb
-require 'chefdk-julia'
-chefdk.generator_cookbook Chefdk::Julia.path
+if defined?(ChefDK::CLI)
+  require 'chefdk/julia'
+  chefdk.generator_cookbook ChefDK::Julia.path
+end
 ```
 
 ## Generating a cookbook

--- a/chefdk-julia.gemspec
+++ b/chefdk-julia.gemspec
@@ -18,7 +18,7 @@ require 'chefdk/julia/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'chefdk-julia'
-  spec.version       = Chefdk::Julia::VERSION
+  spec.version       = ChefDK::Julia::VERSION
   spec.authors       = ['Orion Ifland', 'Doug Ireton']
   spec.email         = ['orion.ifland@nordstrom.com', 'doug.ireton@nordstrom.com']
   spec.license       = 'Apache-2.0'
@@ -35,7 +35,9 @@ Gem::Specification.new do |spec|
   spec.post_install_message = <<-EOF
     Paste lines below into your ~/.chef/config.rb or knife.rb
 
-    require 'chefdk-julia'
-    chefdk.generator_cookbook Chefdk::Julia.path
+    if defined?(ChefDK::CLI)
+      require 'chefdk/julia'
+      chefdk.generator_cookbook ChefDK::Julia.path
+    end
   EOF
 end

--- a/lib/chefdk/julia.rb
+++ b/lib/chefdk/julia.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module Chefdk
+module ChefDK
   # namespace for path method
   module Julia
     def self.path

--- a/lib/chefdk/julia/version.rb
+++ b/lib/chefdk/julia/version.rb
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module Chefdk
+module ChefDK
   # namespace for VERSION constant
   module Julia
-    VERSION = '0.4.2'
+    VERSION = '0.4.3'
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -27,4 +27,4 @@ name File.basename(File.dirname(__FILE__))
 description 'An Opinionated Cookbook Creator'
 long_description 'An Opinionated Cookbook Creator, with spunk and a grin, by Nordstrom'
 
-version Chefdk::Julia::VERSION
+version ChefDK::Julia::VERSION


### PR DESCRIPTION
Corrected README to say this:

```ruby
if defined?(ChefDK::CLI)
  require 'chefdk/julia'
  chefdk.generator_cookbook ChefDK::Julia.path
end
```

This addresses half of @philoserf's issue. If you uninstall `chefdk-julia` and then run `knife` commands everything will work as expected because `ChefDK::CLI` is only defined when you are running a `chef` command.

Running `chef generate cookbook` with the gem missing will throw an error since it's trying to require a missing gem. I think this is the behavior we want since you've explicitly told us you want to use our generator but you don't have the gem available.

```
ERROR: You have an error in your config file C:/Users/mark/.chef/config.rb

LoadError: cannot load such file -- chefdk/julia
  C:/Users/mark/.chef/config.rb:40:in `from_string'
Relevant file content:
 39: if defined?(ChefDK::CLI)
 40:   require 'chefdk/julia'
 41:   chefdk.generator_cookbook Chefdk::Julia.path
```

I'd like to release this to get folks working and then revisit this issue. It seems a bit like this is an edge case.