### PR TITLE
Revert "Added chefspec coverage task to Rakefile"

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,19 +25,12 @@ FoodCritic::Rake::LintTask.new do |foodcritic|
   foodcritic.options[:fail_tags] = 'any'
 end
 
-RSpec::Core::RakeTask.new(:chefspec)
+RSpec::Core::RakeTask.new
 
 desc 'Run Rubocop and Foodcritic style checks'
 task style: [:rubocop, :foodcritic]
 
 desc 'Run all style checks and unit tests'
 task test: [:style, :spec]
-
-desc 'Generate ChefSpec coverage report'
-task :coverage do
-  ENV['COVERAGE'] = 'true'
-  Rake::Task[:chefspec].invoke
-end
-task spec: :chefspec
 
 task default: :test

--- a/lib/chefdk/julia/version.rb
+++ b/lib/chefdk/julia/version.rb
@@ -15,6 +15,6 @@
 module ChefDK
   # namespace for VERSION constant
   module Julia
-    VERSION = '0.4.3'.freeze
+    VERSION = '0.4.3'
   end
 end

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -42,11 +42,11 @@ end
 
 directories_to_create = %w( cookbooks data_bags )
 
-directories_to_create += if context.use_roles
-                           %w( roles environments )
-                         else
-                           %w( policies )
-                         end
+if context.use_roles
+  directories_to_create += %w( roles environments )
+else
+  directories_to_create += %w( policies )
+end
 
 directories_to_create.each do |tlo|
   remote_directory "#{repo_dir}/#{tlo}" do


### PR DESCRIPTION
Reverts Nordstrom/chefdk-julia#15

Looks like we changed the chefdk-julia project Rakefile instead of the `files/default/Rakefile` which `chefdk-julia` **the generator** uses when it creates a new end-user cookbook.

I'll work up a change to `files/default/Rakefile` and resubmit.