### PR TITLE
Release 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ bin/*
 
 # RSpec
 /spec/examples.txt
+
+# Gem-related
+/pkg/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,25 @@
 # Changelog for chefdk-julia
 
+## 1.0.0
+* Set InSpec as the verifier in generated .kitchen.yml [#22](https://github.com/Nordstrom/chefdk-julia/issues/22)
+
+* Remove support for ServerSpec
+
+* Switch from ServerRunner to SoloRunner in generated specs [#21](https://github.com/Nordstrom/chefdk-julia/issues/21)
+
+* Remove `require 'spec_helper'` line from generated specs [#20](https://github.com/Nordstrom/chefdk-julia/issues/20)
+
+* Remove berksfile.lock from generated .gitignore [#18](https://github.com/Nordstrom/chefdk-julia/issues/18)
+
+* Add minimum ChefDK version in README [#14](https://github.com/Nordstrom/chefdk-julia/issues/14)
+
+* Add Windows platform to generated .kitchen.yml
+
+* Add ChefSpec coverage task to generated Rakefile
+
 ## 0.4.4
 * Fix foodcritic.options[:fail_tags] in generated cookbook Rakefile
+
 * Add "How is it better than the basic ChefDK generator?" section to README
 
 ## 0.4.3

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Generated Cookbooks will contain:
 
 
 ## Prerequisites
-[ChefDK](https://downloads.chef.io/chef-dk/) must already be installed.
+[ChefDK](https://downloads.chef.io/chef-dk/) version 0.10 or greater must already be installed.
 
 ## Installation
 

--- a/files/default/Rakefile
+++ b/files/default/Rakefile
@@ -19,3 +19,9 @@ desc 'Run all style checks and unit tests'
 task test: [:style, :spec]
 
 task default: :test
+
+desc 'Generate ChefSpec coverage report'
+task :coverage do
+  ENV['COVERAGE'] = 'true'
+  Rake::Task[:spec].invoke
+end

--- a/files/default/gitignore
+++ b/files/default/gitignore
@@ -1,5 +1,4 @@
 .vagrant
-Berksfile.lock
 *~
 *#
 .#*

--- a/files/default/serverspec_spec_helper.rb
+++ b/files/default/serverspec_spec_helper.rb
@@ -1,8 +1,0 @@
-require 'serverspec'
-
-if (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM).nil?
-  set :backend, :exec
-else
-  set :backend, :cmd
-  set :os, family: 'windows'
-end

--- a/lib/chefdk/julia/version.rb
+++ b/lib/chefdk/julia/version.rb
@@ -15,6 +15,6 @@
 module ChefDK
   # namespace for VERSION constant
   module Julia
-    VERSION = '0.4.4'.freeze
+    VERSION = '1.0.0'.freeze
   end
 end

--- a/recipes/app.rb
+++ b/recipes/app.rb
@@ -28,21 +28,12 @@ template "#{app_dir}/.kitchen.yml" do
   helpers(ChefDK::Generator::TemplateHelper)
 end
 
-directory "#{app_dir}/test/integration/default/serverspec" do
+directory "#{app_dir}/test/integration/default" do
   recursive true
 end
 
-directory "#{app_dir}/test/integration/helpers/serverspec" do
-  recursive true
-end
-
-cookbook_file "#{app_dir}/test/integration/helpers/serverspec/spec_helper.rb" do
-  source 'serverspec_spec_helper.rb'
-  action :create_if_missing
-end
-
-template "#{app_dir}/test/integration/default/serverspec/default_spec.rb" do
-  source 'serverspec_default_spec.rb.erb'
+template "#{app_dir}/test/integration/default/default_spec.rb" do
+  source 'inspec_default_spec.rb.erb'
   helpers(ChefDK::Generator::TemplateHelper)
   action :create_if_missing
 end

--- a/recipes/cookbook.rb
+++ b/recipes/cookbook.rb
@@ -44,7 +44,7 @@ else
   end
 end
 
-# Test-kitchen and ServerSpec
+# Test-kitchen and InSpec
 template "#{cookbook_dir}/.kitchen.yml" do
   if context.use_berkshelf
     source 'kitchen.yml.erb'
@@ -55,22 +55,13 @@ template "#{cookbook_dir}/.kitchen.yml" do
   action :create_if_missing
 end
 
-directory "#{cookbook_dir}/test/integration/default/serverspec" do
+directory "#{cookbook_dir}/test/integration/default" do
   recursive true
 end
 
-template "#{cookbook_dir}/test/integration/default/serverspec/default_spec.rb" do
-  source 'serverspec_default_spec.rb.erb'
+template "#{cookbook_dir}/test/integration/default/default_spec.rb" do
+  source 'inspec_default_spec.rb.erb'
   helpers(ChefDK::Generator::TemplateHelper)
-  action :create_if_missing
-end
-
-directory "#{cookbook_dir}/test/integration/helpers/serverspec" do
-  recursive true
-end
-
-cookbook_file "#{cookbook_dir}/test/integration/helpers/serverspec/spec_helper.rb" do
-  source 'serverspec_spec_helper.rb'
   action :create_if_missing
 end
 

--- a/spec/unit/recipes/cookbook_spec.rb
+++ b/spec/unit/recipes/cookbook_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'chefdk-julia::cookbook' do
 
   it 'generated cookbook spec relies on --require spec_helper in .rspec file' do
     expect(chef_run).to render_file(File.join(new_cookbook_path, '.rspec')).with_content(
-      /--require spec_helper/
+      /^--require spec_helper$/
     )
 
     expect(chef_run).to render_file(

--- a/spec/unit/recipes/cookbook_spec.rb
+++ b/spec/unit/recipes/cookbook_spec.rb
@@ -15,22 +15,45 @@
 require 'chef-dk/generator'
 
 RSpec.describe 'chefdk-julia::cookbook' do
-  def generator_context(use_berkshelf: true)
-    double('generator_context',
-           cookbook_root: '/Users/my_user/chef/cookbooks',
-           cookbook_name: 'my_cookbook',
-           use_berkshelf: use_berkshelf,
-           have_git: true,
-           skip_git_init: false
-          )
-  end
+  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+
+  let(:cookbook_root) { '/Users/my_user/chef/cookbooks' }
+  let(:cookbook_name) { 'my_cookbook' }
+  let(:new_cookbook_path) { File.join(cookbook_root, cookbook_name) }
+
+  let(:license) { 'all_rights' }
+  let(:copyright_holder) { 'Nordstrom' }
 
   before(:example) do
-    allow(ChefDK::Generator).to receive(:context).and_return(generator_context)
+    ChefDK::Generator.reset
+    ChefDK::Generator.add_attr_to_context(:use_berkshelf, true)
+    ChefDK::Generator.add_attr_to_context(:cookbook_root, cookbook_root)
+    ChefDK::Generator.add_attr_to_context(:cookbook_name, cookbook_name)
+    ChefDK::Generator.add_attr_to_context(:have_git, true)
+    ChefDK::Generator.add_attr_to_context(:skip_git_init, false)
+    ChefDK::Generator.add_attr_to_context(:license, license)
+    ChefDK::Generator.add_attr_to_context(:copyright_holder, copyright_holder)
   end
 
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
-  let(:new_cookbook_path) { '/Users/my_user/chef/cookbooks/my_cookbook' }
+  it 'creates a .kitchen.yml' do
+    expect(chef_run).to create_template_if_missing(
+      File.join(new_cookbook_path, '.kitchen.yml')
+    ).with(
+      source: 'kitchen.yml.erb'
+    )
+  end
+
+  it 'enables InSpec in the .kitchen.yml' do
+    expect(chef_run).to render_file(File.join(new_cookbook_path, '.kitchen.yml')).with_content(
+      /^  name: inspec$/
+    )
+  end
+
+  it '.kitchen.yml has a Windows 2012r2 platform' do
+    expect(chef_run).to render_file(File.join(new_cookbook_path, '.kitchen.yml')).with_content(
+      /  - name: windows-2012r2/
+    )
+  end
 
   it 'creates a stock .rspec config file if missing' do
     expect(chef_run).to create_cookbook_file_if_missing(
@@ -54,6 +77,34 @@ RSpec.describe 'chefdk-julia::cookbook' do
     )
   end
 
+  it 'uses SoloRunner in the generated cookbook spec' do
+    expect(chef_run).to render_file(
+      File.join(new_cookbook_path, '/spec/unit/recipes/default_spec.rb')
+    ).with_content(
+      /ChefSpec::SoloRunner\.new/
+    )
+  end
+
+  it 'generated cookbook spec relies on --require spec_helper in .rspec file' do
+    expect(chef_run).to render_file(File.join(new_cookbook_path, '.rspec')).with_content(
+      /--require spec_helper/
+    )
+
+    expect(chef_run).to render_file(
+      File.join(new_cookbook_path, '/spec/unit/recipes/default_spec.rb')
+    ).with_content { |content|
+      expect(content).to_not match(/^require ['"]spec_helper['"]$/)
+    }
+  end
+
+  it 'Generated InSpec spec has a valid example spec' do
+    expect(chef_run).to render_file(
+      File.join(
+        new_cookbook_path, '/test/integration/default/default_spec.rb'
+      )
+    ).with_content(/^describe command/)
+  end
+
   context 'when generating a cookbook which uses Berkshelf' do
     it 'creates a spec_helper if missing' do
       expect(chef_run).to create_template_if_missing(
@@ -72,9 +123,7 @@ RSpec.describe 'chefdk-julia::cookbook' do
 
   context 'when generating a cookbook which uses Policyfiles' do
     before(:example) do
-      allow(ChefDK::Generator).to receive(:context).and_return(
-        generator_context(use_berkshelf: false)
-      )
+      ChefDK::Generator.add_attr_to_context(:use_berkshelf, false)
     end
 
     it 'creates a spec_helper which requires chefspec/policyfile' do

--- a/templates/default/inspec_default_spec.rb.erb
+++ b/templates/default/inspec_default_spec.rb.erb
@@ -1,0 +1,5 @@
+# See InSpec docs for more info: https://docs.chef.io/compliance.html#audit-resources
+
+describe command('whoami') do
+  it { should exist }
+end

--- a/templates/default/kitchen.yml.erb
+++ b/templates/default/kitchen.yml.erb
@@ -5,14 +5,15 @@ driver:
 provisioner:
   name: chef_zero
 
-# Uncomment the following verifier to leverage Inspec instead of Busser (the
-# default verifier)
-# verifier:
-#   name: inspec
+verifier:
+  name: inspec
 
 platforms:
-  - name: ubuntu-14.04
-  - name: centos-7.1
+  - name: ubuntu-16.04
+  - name: centos-7.2
+  - name: windows-2012r2
+    driver_config:
+      box: mwrock/Windows2012R2
 
 suites:
   - name: default

--- a/templates/default/recipe_spec.rb.erb
+++ b/templates/default/recipe_spec.rb.erb
@@ -4,12 +4,10 @@
 #
 <%= license_description('#') %>
 
-require 'spec_helper'
-
 RSpec.describe '<%= cookbook_name %>::<%= recipe_name %>' do
   context 'When all attributes are default, on an unspecified platform' do
     let(:chef_run) do
-      runner = ChefSpec::ServerRunner.new
+      runner = ChefSpec::SoloRunner.new
       runner.converge(described_recipe)
     end
 

--- a/templates/default/serverspec_default_spec.rb.erb
+++ b/templates/default/serverspec_default_spec.rb.erb
@@ -1,9 +1,0 @@
-require 'spec_helper'
-
-describe '<%= cookbook_name %>::default' do
-  # Serverspec examples can be found at
-  # http://serverspec.org/resource_types.html
-  it 'does something' do
-    skip 'Replace this with meaningful tests'
-  end
-end

--- a/templates/default/spec_spec_helper.rb.erb
+++ b/templates/default/spec_spec_helper.rb.erb
@@ -92,3 +92,5 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 end
+
+ChefSpec::Coverage.start! if ENV['COVERAGE']


### PR DESCRIPTION
Remove support for ServerSpec

Fix #22 Set InSpec as the verifier in generated .kitchen.yml

Fix #21: Switch from ServerRunner to SoloRunner in generated specs because SoloRunner
is much faster.

Fix #20: Remove `require 'spec_helper'` line from generated specs.

Fix #18: Remove berksfile.lock from generated .gitignore

Fix #14: Add minimum ChefDK version in README

* Add Windows platform to generated .kitchen.yml

* Add ChefSpec coverage task to generated Rakefile 