### PR TITLE
Include cookstyle in default Rakefile

### DIFF
--- a/files/default/Rakefile
+++ b/files/default/Rakefile
@@ -1,3 +1,4 @@
+require 'cookstyle'
 require 'rubocop/rake_task'
 require 'foodcritic'
 require 'rspec/core/rake_task'


### PR DESCRIPTION
This just uses cookstyle, the version pinned rubocop. Not much different than vanilla rubocop setup, still allows override with .rubocop.yml if desired. 

ref: https://github.com/chef/cookstyle#rake
